### PR TITLE
Fix `AttributeError` when getting markers

### DIFF
--- a/pipenv_to_requirements/__init__.py
+++ b/pipenv_to_requirements/__init__.py
@@ -35,7 +35,7 @@ def clean_version(pkg_name, pkg_info):
         return pkg_name
     version = pkg_info.get("version", "").strip()
     editable = pkg_info.get("editable", False)
-    markers = pkg_info.get("markers", "").strip()
+    markers = pkg_info["markers"].strip() if pkg_info.get("markers") else ""
     extras = pkg_info.get("extras", [])
     subdir = pkg_info.get("subdirectory", [])
     git = pkg_info.get("git", "").strip()


### PR DESCRIPTION
Some versions of pipenv generate Pipfile.lock whith wrong markers section (`"markers": null`)

```python
File "/usr/local/bin/pipenv_to_requirements", line 11, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.6/site-packages/pipenv_to_requirements/__init__.py", line 85, in main
    def_req = parse_pip_file(pipfile, "default")
  File "/usr/local/lib/python3.6/site-packages/pipenv_to_requirements/__init__.py", line 65, in parse_pip_file
    return [clean_version(n, i) for n, i in pipfile.get(section, {}).items()]
  File "/usr/local/lib/python3.6/site-packages/pipenv_to_requirements/__init__.py", line 65, in <listcomp>
    return [clean_version(n, i) for n, i in pipfile.get(section, {}).items()]
  File "/usr/local/lib/python3.6/site-packages/pipenv_to_requirements/__init__.py", line 38, in clean_version
    markers = pkg_info.get("markers", "").strip()
AttributeError: 'NoneType' object has no attribute 'strip'
```