### PR TITLE
Fix Issue #12 about missing markers

### DIFF
--- a/pipenv_to_requirements/__init__.py
+++ b/pipenv_to_requirements/__init__.py
@@ -59,11 +59,6 @@ def clean_version(pkg_name, pkg_info):
     return rstr
 
 
-def formatPipenvEntryForRequirements(pkg_name, pkg_info):
-    return clean_version(pkg_name,
-                         pkg_info["version"].strip() if "version" in pkg_info else pkg_info)
-
-
 def parse_pip_file(pipfile, section):
     return [clean_version(n, i) for n, i in pipfile.get(section, {}).items()]
 
@@ -99,13 +94,8 @@ def main():
         pipfile = Project()._lockfile
         # pylint: enable=protected-access
 
-    # Create pip-compatible dependency list
-    def_req = [
-        formatPipenvEntryForRequirements(n, i) for n, i in pipfile.get("default", {}).items()
-    ]
-    dev_req = [
-        formatPipenvEntryForRequirements(n, i) for n, i in pipfile.get("develop", {}).items()
-    ]
+    def_req = parse_pip_file(pipfile, 'default')
+    dev_req = parse_pip_file(pipfile, "develop")
 
     intro = [
         "################################################################################",

--- a/pipenv_to_requirements/test_cli.py
+++ b/pipenv_to_requirements/test_cli.py
@@ -28,8 +28,6 @@ def fake_pipenv(mocker):
     }
     fake_pipenv_project.return_value = fake_pipenv_project2
     mocker.patch("pipenv_to_requirements.parse_pip_file")
-    mocker.patch(
-        "pipenv_to_requirements.formatPipenvEntryForRequirements", side_effect=lambda x, y: x)
 
 
 def test_no_opt(fake_pipenv, mocker, fs):

--- a/pipenv_to_requirements/test_parsing.py
+++ b/pipenv_to_requirements/test_parsing.py
@@ -20,7 +20,7 @@ class TestParsing(object):
     @staticmethod
     def load_requirements(name):
         with open(os.path.join(VECTORS_FOLDER, name)) as f:
-            return [l.strip() for l in f.readlines()]
+            return [l.strip() for l in f.readlines() if l.strip()]
 
     @staticmethod
     def load_vector_pipfile(name):
@@ -62,6 +62,5 @@ class TestParsing(object):
         expected_requirements = self.load_requirements("Pipfile.markers.requirements.txt")
         assert sorted(requirements) == sorted(expected_requirements)
 
-        print(requirements_dev)
         expected_requirements_dev = self.load_requirements("Pipfile.markers.requirements-dev.txt")
         assert sorted(requirements_dev) == sorted(expected_requirements_dev)

--- a/pipenv_to_requirements/vectors/Pipfile.markers
+++ b/pipenv_to_requirements/vectors/Pipfile.markers
@@ -15,6 +15,7 @@ cryptography = ">=1.4"
 pyyaml = ">=3.11"
 tox = "*"
 future = {version = "*", markers = "python_version < '3.0'"}
+libvirt-python = {version = "==4.10.0", markers="platform_system=='Linux'"}
 
 
 [packages]

--- a/pipenv_to_requirements/vectors/Pipfile.markers.requirements-dev.txt
+++ b/pipenv_to_requirements/vectors/Pipfile.markers.requirements-dev.txt
@@ -7,3 +7,5 @@ pylint>=1.7
 pyyaml>=3.11
 tox
 yapf>=0.18
+libvirt-python==4.10.0 ; platform_system=='Linux'
+


### PR DESCRIPTION
Fix https://github.com/gsemet/pipenv-to-requirements/issues/12

Please review carefully, I don't know why `formatPipenvEntryForRequirements` was there in the first place, but it prevented all markers to find their way into the requirement files.