### PR TITLE
Fix compatibility with pipenv >= 2022.10.9

### DIFF
--- a/pipenv_to_requirements/__init__.py
+++ b/pipenv_to_requirements/__init__.py
@@ -111,6 +111,8 @@ def main():
         # pylint: disable=protected-access
         pipfile = Project()._lockfile
         # pylint: enable=protected-access
+        if callable(pipfile):
+            pipfile = pipfile()
 
     def_req = parse_pip_file(pipfile, 'default')
     dev_req = parse_pip_file(pipfile, "develop")


### PR DESCRIPTION
`Project._lockfile` became a function instead of a property in https://github.com/pypa/pipenv/commit/b3381ce4e89da318506637c55fc97f61c73f7dbf, which is shipped in pipenv since version 2022.10.9.

Adding a simple compatibility fix here fixes it for me.

Fixes #25